### PR TITLE
chore(leaf): add cached async image as leaf dependency

### DIFF
--- a/mobile/evidence/ios/Evidence.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/evidence/ios/Evidence.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swiftui-cached-async-image",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:lorenzofiamingo/swiftui-cached-async-image.git",
+      "state" : {
+        "revision" : "467a3d17479887943ab917a379e62bbaff60ac8a",
+        "version" : "2.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/mobile/evidence/ios/EvidenceDependencies/Package.swift
+++ b/mobile/evidence/ios/EvidenceDependencies/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
     products: [
         .library(
             name: "EvidenceDependencies",
-            targets: ["EvidenceDependencies"]),
+            targets: ["EvidenceDependencies"]
+        ),
     ],
     dependencies: [
         .package(path: "../Leaf")
@@ -19,6 +20,7 @@ let package = Package(
     targets: [
         .target(
             name: "EvidenceDependencies",
-            dependencies: ["Leaf"]),
+            dependencies: ["Leaf"]
+        ),
     ]
 )

--- a/mobile/evidence/ios/Leaf/Package.swift
+++ b/mobile/evidence/ios/Leaf/Package.swift
@@ -11,14 +11,22 @@ let package = Package(
     products: [
         .library(
             name: "Leaf",
-            targets: ["Leaf"]),
+            targets: ["Leaf"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/lorenzofiamingo/swiftui-cached-async-image", from: "2.1.1"),
     ],
     targets: [
         .target(
             name: "Leaf",
-            dependencies: []),
+            dependencies: [
+                .product(name: "CachedAsyncImage", package: "swiftui-cached-async-image")
+            ]
+        ),
         .testTarget(
             name: "LeafTests",
-            dependencies: ["Leaf"]),
+            dependencies: ["Leaf"]
+        ),
     ]
 )


### PR DESCRIPTION
## Description, motivation and context
Adds CachedAsyncImage package as Leaf dependency using `EvidenceDependencies`.

## Checklist :leaves:
<!-- Check all items that apply. -->
- [ ] Created all unit tests needed

Thank you!
