### PR TITLE
chore(leaf): avatar style

### DIFF
--- a/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAvatar.swift
+++ b/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAvatar.swift
@@ -1,82 +1,47 @@
 import SwiftUI
 import CachedAsyncImage
 
-struct LeafAvatar: View {
-    let urlImage: URL?
+public struct LeafAvatar: View {
+    private let url: URL
+    @Environment(\.leafAvatarStyle) private var style
     
-    var body: some View {
-        CachedAvatarImage(url: urlImage)
+    public init(url: URL) {
+        self.url = url
+    }
+    
+    public var body: some View {
+        let configuration = LeafAvatarConfiguration(avatar: AnyView(
+            CachedAsyncImage(url: url) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image
+                        .resizable()
+                case .failure(_):
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .resizable()
+                @unknown default:
+                    Image(systemName: "person.circle.fill")
+                        .resizable()
+                }
+            }
+        ))
+        
+        AnyView(style.makeBody(configuration: configuration))
     }
 }
 
 #Preview {
-    LeafThemeView {
-        LeafAvatar(urlImage: URL(string: "https://shorturl.at/uyWY2"))
-    }
-}
-
-//MARK: View Extraction
-
-struct CachedAvatarImage: View {
-    let url: URL?
+    let url1 = "https://pbs.twimg.com/profile_images/1694966619875708928/rbZorQR2_400x400.jpg"
+    let url2 = "https://pbs.twimg.com/profile_images/1584303098687885312/SljBjw26_400x400.jpg"
     
-    var body: some View {
-        CachedAsyncImage(url: url) { phase in
-            switch phase {
-            case .empty:
-                ProgressView()
-                    .frame(width: 43, height: 43)
-            case .success(let image):
-                SuccessImage(image: image)
-            case .failure(_):
-                ImageView(systemImage: "exclamationmark.circle.fill")
-            @unknown default:
-                ImageView(systemImage: "person.circle.fill")
-            }
+    return LeafThemeView {
+        HStack {
+            LeafAvatar(url: URL(string: url1)!)
+                .avatarStyle(.evident)
+            LeafAvatar(url: URL(string: url2)!)
+                .avatarStyle(.automatic)
         }
-    }
-}
-
-
-struct SuccessImage: View {
-    let sizeImage: CGFloat = 43
-    let sizeCircle: CGFloat = 50
-    let image: Image
-    @Environment(\.leafTheme) private var theme
-    
-    var body: some View {
-        image
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: sizeImage, height: sizeImage)
-            .foregroundColor(theme.color.content.secondary)
-            .cornerRadius(sizeImage/2)
-            .overlay {
-                Circle()
-                    .stroke(theme.color.brand.primary, lineWidth: 3)
-                    .frame(width: sizeCircle, height: sizeCircle)
-            }
-    }
-}
-
-
-struct ImageView: View {
-    let sizeImage: CGFloat = 43
-    let sizeCircle: CGFloat = 50
-    var systemImage: String
-    @Environment(\.leafTheme) private var theme
-    
-    var body: some View {
-        Image(systemName: systemImage )
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: sizeImage, height: sizeImage)
-            .foregroundColor(theme.color.content.secondary)
-            .cornerRadius(sizeImage/2)
-            .overlay {
-                Circle()
-                    .stroke(theme.color.brand.primary, lineWidth: 3)
-                    .frame(width: sizeCircle, height: sizeCircle)
-            }
     }
 }

--- a/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAvatarStyle.swift
+++ b/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAvatarStyle.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+///
+public protocol LeafAvatarStyle {
+    associatedtype Body : View
+    
+    func makeBody(configuration: Self.Configuration) -> Self.Body
+    
+    typealias Configuration = LeafAvatarConfiguration
+}
+
+///
+public struct LeafAvatarConfiguration {
+    public let avatar: AnyView
+}
+
+///
+extension LeafAvatarStyle where Self == AutomaticLeafAvatarStyle {
+    public static var automatic: Self { .init() }
+}
+
+extension LeafAvatarStyle where Self == EvidentLeafAvatarStyle {
+    public static var evident: Self { .init() }
+}
+
+///
+public struct AutomaticLeafAvatarStyle: LeafAvatarStyle {
+    private let size = CGSize(width: 43, height: 43)
+    
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.avatar
+            .frame(width: size.width, height: size.height)
+            .cornerRadius(size.width/2)
+            .overlay {
+                Circle().stroke(.tint, lineWidth: 3)
+            }
+    }
+}
+
+///
+public struct EvidentLeafAvatarStyle: LeafAvatarStyle {
+    private let size = CGSize(width: 64, height: 64)
+    
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.avatar
+            .frame(width: size.width, height: size.height)
+            .cornerRadius(size.width/2)
+            .overlay {
+                Circle().stroke(.tint, lineWidth: 3)
+            }
+    }
+}
+
+///
+public struct LeafAvatarStyleKey: EnvironmentKey {
+    public static let defaultValue: any LeafAvatarStyle = .automatic
+}
+
+extension EnvironmentValues {
+    public var leafAvatarStyle: any LeafAvatarStyle {
+        get { self[LeafAvatarStyleKey.self] }
+        set { self[LeafAvatarStyleKey.self] = newValue }
+    }
+}
+
+extension View {
+    public func avatarStyle<S>(_ style: S) -> some View where S: LeafAvatarStyle {
+        environment(\.leafAvatarStyle, style)
+    }
+}

--- a/mobile/evidence/ios/Leaf/Sources/Leaf/Theme/LeafThemeView.swift
+++ b/mobile/evidence/ios/Leaf/Sources/Leaf/Theme/LeafThemeView.swift
@@ -15,5 +15,6 @@ public struct LeafThemeView<C: View>: View {
     public var body: some View {
         childView
             .environment(\.leafTheme, theme)
+            .tint(theme.color.brand.primary)
     }
 }


### PR DESCRIPTION
## Description, motivation and context
- Moves styling logic into `LeafAvatarStyle` while maintaining specific view rendering and interaction in LeafAvatar component
- Adds `leafAvatarStyle` view extension to allow updating avatar style environment variable, similar to what can be done with `buttonStyle` and other SwiftUI view styles.

For this component, style is responsible for managing overlay (width and color) and whole component size.

## Screenshots and GIFs (Artifacts)
<img width="1840" alt="Screenshot 2023-10-17 at 15 23 13" src="https://github.com/viniciusaro/evidence/assets/6593876/05a11e4b-85bc-4b68-b1c5-705110497114">

## Checklist :leaves:
<!-- Check all items that apply. -->
- [ ] Created all unit tests needed

Thank you!
