### PR TITLE
Fix[Leaf] - Tag access control

### DIFF
--- a/mobile/evidence/ios/Evidence/Evidence/ContentView.swift
+++ b/mobile/evidence/ios/Evidence/Evidence/ContentView.swift
@@ -4,13 +4,19 @@ import Leaf
 struct ContentView: View {
     var body: some View {
             VStack(alignment: .leading) {
-                VStack(alignment:.leading) {
-                    Text("kstewart")
-                        .subtitle()
-                        .padding(.bottom, 1)
-                    Text("76 answers - 100 views")
-                        .label()
-                        .padding(.bottom)
+                HStack(alignment: .top) {
+                    LeafAvatar(url: URL.documentsDirectory)
+                        .avatarStyle(.automatic)
+                    VStack(alignment:.leading) {
+                        Text("kstewart")
+                            .subtitle()
+                            .padding(.bottom, 1)
+                        Text("76 answers - 100 views")
+                            .label()
+                            .padding(.bottom)
+                    }
+                    Spacer()
+                    LeafTag("Open", status: .accepted)
                 }
                 Text("If you were to start over, would you choose SwiftUI or UIKit? ")
                     .title()

--- a/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafTag.swift
+++ b/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafTag.swift
@@ -7,18 +7,18 @@
 
 import SwiftUI
 
-struct LeafTag: View {
+public struct LeafTag: View {
     private let text: String
     private let status: StatusTag
     
-    init(_ text: String, status: StatusTag) {
+    public init(_ text: String, status: StatusTag) {
         self.text = text
         self.status = status
     }
     
     @Environment(\.leafTheme) private var theme
     
-    var body: some View {
+    public var body: some View {
         VStack {
             switch status {
             case .open:
@@ -48,7 +48,7 @@ struct LeafTag: View {
 }
 
 ///
-enum StatusTag {
+public enum StatusTag {
     case open, accepted, rejected, closed
 }
 
@@ -57,9 +57,9 @@ extension Text {
     func tagStyle() -> some View {
         self
             .textCase(.uppercase)
-            .font(.callout)
+            .font(.footnote)
             .bold()
-            .padding(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+            .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
     }
 }
 


### PR DESCRIPTION
## Description, motivation and context
- Change the access control of the Leaf/Tag to public
- Change the font size of tag
- Add code on `Evidence/ContentView` to test access control 

## Screenshots and GIFs (Artifacts)
<img width="1440" alt="Screenshot 2023-10-22 at 18 51 17" src="https://github.com/viniciusaro/evidence/assets/72877786/af21cd7c-e9f7-462c-ba73-f82589fb8a51">

## Checklist :leaves:
<!-- Check all items that apply. -->


Thank you!
