### PR TITLE
feature(chat): highlight chat message when id matches setup

### DIFF
--- a/mobile/evidence/ios/Evidence/Evidence.xcodeproj/project.pbxproj
+++ b/mobile/evidence/ios/Evidence/Evidence.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -416,7 +416,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -442,7 +442,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -473,7 +473,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/mobile/evidence/ios/Evidence/Evidence/ContentView.swift
+++ b/mobile/evidence/ios/Evidence/Evidence/ContentView.swift
@@ -32,14 +32,18 @@ struct HomeView: View {
     var body: some View {
         ChatView(
             model: ChatViewModel(
-                chat: Chat(
+                state: ChatViewState(
                     messages: [
-                        Message.hi,
-                        Message.hello,
-                        Message.howAreYouDoing,
-                        Message.mac,
-                        Message.link,
-                    ]
+                        Message.vini("hi"),
+                        Message.vini("hello"),
+                        Message.vini("howAreYouDoing"),
+                        Message.mac(id: UUID(1)),
+                    ].map {
+                        MessageViewModel(
+                            state: MessageViewState(message: $0)
+                        )
+                    },
+                    highlightedMessageId: UUID(1)
                 )
             )
         )

--- a/mobile/evidence/ios/EvidenceDependencies/Package.swift
+++ b/mobile/evidence/ios/EvidenceDependencies/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "EvidenceDependencies",
     platforms: [
-        .iOS(.v16), .macOS(.v12)
+        .iOS(.v17), .macOS(.v12)
     ],
     products: [
         .library(

--- a/mobile/evidence/ios/Features/Package.swift
+++ b/mobile/evidence/ios/Features/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Features",
     platforms: [
-        .iOS(.v16), .macOS(.v13)
+        .iOS(.v17), .macOS(.v13)
     ],
     
     products: [

--- a/mobile/evidence/ios/Features/Sources/Chat/Chat.swift
+++ b/mobile/evidence/ios/Features/Sources/Chat/Chat.swift
@@ -1,44 +1,140 @@
-import SwiftUI
+import Dependencies
+import Leaf
 import Models
+import SwiftUI
 
-public class ChatViewModel: ObservableObject {
-    @Published private(set) var messages: [MessageViewModel]
+public struct ChatViewState: Equatable {
+    var messages: [MessageViewModel]
+    var highlightedMessageId: MessageViewModel.ID?
+    var scrollToMessageId: MessageViewModel.ID?
+    var tempHighlightedMessageId: MessageViewModel.ID?
     
-    public init(chat: Chat) {
-        self.messages = chat.messages.map { MessageViewModel(message: $0) }
+    public init(
+        messages: [MessageViewModel],
+        highlightedMessageId: MessageViewModel.ID? = nil
+    ) {
+        self.messages = messages
+        self.highlightedMessageId = nil
+        self.scrollToMessageId = nil
+        self.tempHighlightedMessageId = highlightedMessageId
+    }
+}
+
+@MainActor
+public class ChatViewModel: ObservableObject {
+    @Published var state: ChatViewState
+    @Dependency(\.suspendingClock) private var clock
+
+    private var highlightTask: Task<(), Never>?
+    
+    public init(state: ChatViewState) {
+        self.state = state
+    }
+    
+    public func onViewAppear() {
+        self.highlightMessageIfNeeded();
+    }
+    
+    public func isHighlighted(_ messageModel: MessageViewModel) -> Bool {
+        return messageModel.id == self.state.highlightedMessageId
+    }
+    
+    private func highlightMessageIfNeeded() {
+        self.highlightTask = Task { [weak self] in
+            guard
+                let self = self,
+                let id = self.state.tempHighlightedMessageId else { return }
+            
+            self.state.tempHighlightedMessageId = nil
+            try? await self.clock.sleep(for: .seconds(1))
+            
+            self.state.scrollToMessageId = id
+            self.state.highlightedMessageId = id
+            
+            try? await self.clock.sleep(for: .seconds(2))
+            self.state.scrollToMessageId = nil
+            self.state.highlightedMessageId = nil
+        }
+    }
+    
+    deinit {
+        self.highlightTask?.cancel()
+        self.highlightTask = nil
     }
 }
 
 public struct ChatView: View {
     @ObservedObject var model: ChatViewModel
+    @Environment(\.leafTheme) var theme
     
     public init(model: ChatViewModel) {
         self.model = model
     }
     
     public var body: some View {
-        List(self.model.messages.reversed()) { model in
-            MessageView(model: model)
-                .rotationEffect(.radians(.pi))
+        NavigationView {
+            ScrollView {
+                LazyVStack(alignment: .leading) {
+                    ForEach(self.model.state.messages) { messageModel in
+                        MessageView(model: messageModel)
+                            .background(
+                                self.model.isHighlighted(messageModel) ?
+                                self.theme.color.brand.secondary : nil
+                            )
+                            .animation(
+                                Animation.easeIn,
+                                value: self.model.isHighlighted(messageModel)
+                            )
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollPosition(id: self.$model.state.scrollToMessageId)
+            .navigationTitle("Chat")
         }
-        .rotationEffect(.radians(.pi))
-        .listStyle(.plain)
+        .onAppear { self.model.onViewAppear() }
     }
 }
 
 #Preview {
     ChatView(
         model: ChatViewModel(
-            chat: Chat(
+            state: ChatViewState(
                 messages: [
-                    Message.hi,
-                    Message.hello,
-                    Message.howAreYouDoing,
-                    Message.mac,
-                    Message.tabNews,
-                    Message.link,
-                    Message.pr(3),
-                ]
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                    Message.mac(id: UUID(1)),
+                    Message.vini("hi"),
+                    Message.vini("hello"),
+                    Message.vini("howAreYouDoing"),
+                ].map {
+                    MessageViewModel(
+                        state: MessageViewState(message: $0)
+                    )
+                },
+                highlightedMessageId: UUID(1)
             )
         )
     )

--- a/mobile/evidence/ios/Features/Sources/Chat/Message.swift
+++ b/mobile/evidence/ios/Features/Sources/Chat/Message.swift
@@ -1,44 +1,55 @@
 import Combine
 import Dependencies
+import Leaf
 import Models
 import SwiftUI
 
-struct MessageViewState: Equatable {
-    var loading: Bool
-    var message: Message
-    var preview: Preview?
+public struct MessageViewState: Equatable {
+    public var loading: Bool
+    public var message: Message
+    public var preview: Preview?
     
-    init(message: Message, loading: Bool = false, preview: Preview? = nil) {
+    public struct Preview: Equatable {
+        let image: URL
+        let title: String
+    }
+    
+    public init(
+        message: Message,
+        loading: Bool = false, 
+        preview: Preview? = nil
+    ) {
         self.loading = loading
         self.message = message
         self.preview = preview
     }
-    
-    struct Preview: Equatable {
-        let image: URL
-        let title: String
-    }
 }
 
-class MessageViewModel: ObservableObject, Identifiable {
+public class MessageViewModel: Equatable, ObservableObject, Identifiable {
     @Published private(set) var state: MessageViewState
-    @Dependency(\.urlPreviewClient) var urlPreviewClient
+    @Dependency(\.urlPreviewClient) private var urlPreviewClient
     
-    var id: UUID { self.state.message.id }
+    public var id: UUID { self.state.message.id }
     private var previewCancellable: AnyCancellable?
     
-    init(message: Message, 
-         loading: Bool = false,
-         preview: MessageViewState.Preview? = nil
-    ) {
-        self.state = MessageViewState(
-            message: message,
-            loading: loading,
-            preview: preview
-        )
+    public init(state: MessageViewState) {
+        self.state = state
+        self.startWithLoadingIfTheresPreview()
     }
     
-    func onLoad() {
+    func onViewAppear() {
+        self.loadPreviewIfNeeded()
+    }
+    
+    private func startWithLoadingIfTheresPreview() {
+        if let url = URL(string: self.state.message.content),
+           url.host() != nil,
+           self.state.preview == nil {
+                self.state.loading = true
+        }
+    }
+    
+    private func loadPreviewIfNeeded() {
         guard let url = URL(string: self.state.message.content),
             url.host() != nil,
             self.state.preview == nil else { return }
@@ -52,6 +63,10 @@ class MessageViewModel: ObservableObject, Identifiable {
                 self?.state.preview = .init(image: image, title: title)
             }
     }
+    
+    public static func == (lhs: MessageViewModel, rhs: MessageViewModel) -> Bool {
+        lhs.state == rhs.state
+    }
 }
 
 struct MessageView: View {
@@ -59,34 +74,49 @@ struct MessageView: View {
     
     var body: some View {
         VStack(spacing: 16) {
-            HStack {
-                Text(self.model.state.message.content)
-                Spacer()
-                if self.model.state.loading {
-                    ProgressView()
-                }
-            }
+            Text(self.model.state.message.content)
+                .frame(maxWidth: .infinity, alignment: .leading)
             if let preview = self.model.state.preview {
                 VStack(alignment: .leading) {
-                    AsyncImage(
-                        url: preview.image,
-                        content: { image in
+                    LeafAsyncImage(url: preview.image) { status in
+                        switch status {
+                        case let .loaded(image):
                             image.resizable()
                                 .aspectRatio(contentMode: .fill)
                                 .frame(height: 100)
                                 .clipped()
-                        },
-                        placeholder: {
+                        case .loading, .error:
                             Rectangle()
-                                .fill(Color.gray)
+                                .opacity(0)
                                 .frame(height: 100)
                         }
-                    )
+                    }
                     Text(preview.title)
+                        .lineLimit(1)
+                        .font(.caption)
+                }
+            } else if self.model.state.loading {
+                VStack(alignment: .leading) {
+                    Rectangle()
+                        .opacity(0)
+                        .frame(height: 100)
+                    Text("loading")
+                        .redacted(reason: .placeholder)
                         .font(.caption)
                 }
             }
         }
-        .task { self.model.onLoad() }
+        .padding(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+        .onAppear { self.model.onViewAppear() }
+    }
+}
+
+#Preview {
+    LeafThemeView {
+        MessageView(
+            model: MessageViewModel(
+                state: .init(message: .link)
+            )
+        )
     }
 }

--- a/mobile/evidence/ios/Features/Sources/Models/Chat.swift
+++ b/mobile/evidence/ios/Features/Sources/Models/Chat.swift
@@ -10,10 +10,17 @@ public struct Chat: Identifiable, Equatable {
 }
 
 public struct Message: Identifiable, Equatable {
-    public let id = UUID()
+    public let id: UUID
     public var content: String
     public var recipient: Recipient
     public var likes: Int
+    
+    init(id: UUID = UUID(), content: String, recipient: Recipient, likes: Int) {
+        self.id = id
+        self.content = content
+        self.recipient = recipient
+        self.likes = likes
+    }
 }
 
 public struct Recipient: Identifiable, Equatable {
@@ -23,31 +30,42 @@ public struct Recipient: Identifiable, Equatable {
 
 extension Message {
     public static let error = Message(content: "Error!!", recipient: .vini, likes: 0)
-    public static var hi = Message(content: "Hi", recipient: .vini, likes: 0)
-    public static var hello = Message(content: "Hello", recipient: .kristem, likes: 0)
-    public static var howAreYouDoing = Message(content: "How are you doing?", recipient: .vini, likes: 0)
-    public static var link = Message(
+    public static let hi = Message(content: "Hi", recipient: .vini, likes: 0)
+    public static let hello = Message(content: "Hello", recipient: .kristem, likes: 0)
+    public static let howAreYouDoing = Message(content: "How are you doing?", recipient: .vini, likes: 0)
+    public static let link = Message(
         content: "https://www.behance.net/gallery/113252267/UXUI-Case-Study-Hackathon-CCR-2021",
         recipient: .vini,
         likes: 0
     )
-    public static var mac = Message(
-        content: "https://medium.com/@nqtuan86/clean-mac-storage-for-xcodes-users-5fbb32239aa5",
-        recipient: .kristem,
-        likes: 10
-    )
+    public static func mac(id: UUID = UUID()) -> Message {
+        return Message(
+            id: id,
+            content: "https://medium.com/@nqtuan86/clean-mac-storage-for-xcodes-users-5fbb32239aa5",
+            recipient: .kristem,
+            likes: 10
+        )
+    }
     
-    public static var blind = Message(
+    public static let blind = Message(
         content: "https://www.teamblind.com/",
         recipient: .kristem,
         likes: 10
     )
     
-    public static var tabNews = Message(
+    public static let tabNews = Message(
         content: "https://www.tabnews.com.br",
         recipient: .kristem,
         likes: 10
     )
+    
+    public static func vini(id: UUID = UUID(), _ text: String) -> Message {
+        return Message(id: id, content: text, recipient: .vini, likes: 0)
+    }
+    
+    public static func kristem(id: UUID = UUID(), _ text: String) -> Message {
+        return Message(id: id, content: text, recipient: .kristem, likes: 0)
+    }
     
     public static func pr(_ n: Int) -> Message {
         Message(

--- a/mobile/evidence/ios/Features/Sources/TestHelper/Helper.swift
+++ b/mobile/evidence/ios/Features/Sources/TestHelper/Helper.swift
@@ -45,7 +45,7 @@ public func assert<State: Equatable>(
             }
         }
         act()
-        if XCTWaiter.wait(for: [expectation], timeout: 0.01) != .completed {
+        if XCTWaiter.wait(for: [expectation], timeout: 0.5) != .completed {
             XCTFail(
                 "steps not found: \(String(customDumping: mutations))",
                 file: mutations.first?.file ?? file,

--- a/mobile/evidence/ios/Features/Tests/ChatTests/ChatTest.swift
+++ b/mobile/evidence/ios/Features/Tests/ChatTests/ChatTest.swift
@@ -1,0 +1,60 @@
+import Dependencies
+import Models
+import XCTest
+import TestHelper
+
+@testable import Chat
+
+@MainActor
+final class ChatTest: XCTestCase {
+    func testHighlightsMessage() {
+        let messages = [
+            Message.vini(id: UUID(0), "Hi"),
+            Message.kristem(id: UUID(1), "Hello"),
+        ]
+        
+        let viewModel = ChatViewModel(
+            state: ChatViewState(
+                messages: messages.map { MessageViewModel(state: .init(message: $0)) },
+                highlightedMessageId: UUID(0)
+            )
+        )
+        
+        assert(
+            publisher: viewModel.$state,
+            act: { viewModel.onViewAppear() },
+            withDependencies: { $0.suspendingClock = ImmediateClock() },
+            steps: [
+                Step { $0.tempHighlightedMessageId = nil },
+                Step { $0.scrollToMessageId = UUID(0) },
+                Step { $0.highlightedMessageId = UUID(0) },
+                Step { $0.scrollToMessageId = nil },
+                Step { $0.highlightedMessageId = nil },
+            ]
+        )
+    }
+    
+    func testIsHighlighted() async {
+        let clock = TestClock()
+        
+        let messageModel = MessageViewModel(
+            state: MessageViewState(message: .vini(id: UUID(0), "Hi"))
+        )
+        
+        let viewModel = ChatViewModel(
+            state: ChatViewState(messages: [messageModel], highlightedMessageId: UUID(0))
+        )
+        
+        await withDependencies {
+            $0.suspendingClock = clock
+        } operation: {
+            viewModel.onViewAppear()
+            
+            await clock.advance(by: .seconds(1))
+            XCTAssertEqual(viewModel.isHighlighted(messageModel), true)
+            
+            await clock.advance(by: .seconds(2))
+            XCTAssertEqual(viewModel.isHighlighted(messageModel), false)
+        }
+    }
+}

--- a/mobile/evidence/ios/Features/Tests/ChatTests/MessageTests.swift
+++ b/mobile/evidence/ios/Features/Tests/ChatTests/MessageTests.swift
@@ -1,19 +1,17 @@
-import Combine
-import Dependencies
 import XCTest
 import TestHelper
 
 @testable import Chat
 
 class MessageTests: XCTestCase {
-    func testOnLoadSuccess() {
+    func testOnViewAppearSuccess() {
         let image = URL(string: "url")!
         let title = "title"
-        let viewModel = MessageViewModel(message: .link)
+        let viewModel = MessageViewModel(state: MessageViewState(message: .link))
         
         assert(
             publisher: viewModel.$state,
-            act: { viewModel.onLoad() },
+            act: { viewModel.onViewAppear() },
             withDependencies: { $0.urlPreviewClient = .sync((image, title)) },
             steps: [
                 Step { $0.loading = true },
@@ -23,12 +21,12 @@ class MessageTests: XCTestCase {
         )
     }
     
-    func testOnLoadFailure() {
-        let viewModel = MessageViewModel(message: .link)
+    func testOnViewAppearFailure() {
+        let viewModel = MessageViewModel(state: MessageViewState(message: .link))
         
         assert(
             publisher: viewModel.$state,
-            act: { viewModel.onLoad() },
+            act: { viewModel.onViewAppear() },
             withDependencies: { $0.urlPreviewClient = .sync(nil) },
             steps: [
                 Step { $0.loading = true },

--- a/mobile/evidence/ios/Leaf/Package.swift
+++ b/mobile/evidence/ios/Leaf/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAsyncImage.swift
+++ b/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAsyncImage.swift
@@ -2,47 +2,52 @@ import Combine
 import Dependencies
 import SwiftUI
 
-enum LeafAsyncImageStatus {
+public enum LeafAsyncImageStatus {
     case loading
     case loaded(Image)
     case error(Error)
 }
 
 class LeafAsyncImageModel: ObservableObject {
-    @Published 
-    private(set) var status: LeafAsyncImageStatus = .loading
+    @Published private(set) var status: LeafAsyncImageStatus
+    @Dependency(\.leafAsyncImageClient) private var imageClient
+    @Dependency(\.mainQueue) private var mainQueue
     
-    @Dependency(\.leafAsyncImageClient)
-    private var imageClient: LeafAsyncImageClient
     private var imageCancellable: AnyCancellable?
     
     init(url: URL) {
-        self.imageCancellable = self.imageClient.load(url).sink(
-            receiveCompletion: { [weak self] completion in
-                guard let self = self else { return }
-                if case let .failure(error) = completion {
-                    self.status = .error(error)
+        self.status = .loading
+        self.imageCancellable = self.imageClient.load(url)
+            .receive(on: mainQueue)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    guard let self = self else { return }
+                    if case let .failure(error) = completion {
+                        self.status = .error(error)
+                    }
+                },
+                receiveValue: { [weak self] data in
+                    guard let self = self else { return }
+                    self.status = .loaded(data)
                 }
-            },
-            receiveValue: { [weak self] data in
-                guard let self = self else { return }
-                self.status = .loaded(data)
-            }
-        )
+            )
     }
 }
 
-struct LeafAsyncImage: View {
-    @ObservedObject 
+public struct LeafAsyncImage: View {
+    @ObservedObject
     private var model: LeafAsyncImageModel
     private let viewBuilder: (LeafAsyncImageStatus) -> any View
     
-    init(url: URL, @ViewBuilder viewBuilder: @escaping (LeafAsyncImageStatus) -> any View) {
+    public init(
+        url: URL,
+        @ViewBuilder viewBuilder: @escaping (LeafAsyncImageStatus) -> any View
+    ) {
         self.model = LeafAsyncImageModel(url: url)
         self.viewBuilder = viewBuilder
     }
     
-    var body: some View {
+    public var body: some View {
         AnyView(viewBuilder(model.status))
     }
 }

--- a/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAsyncImageClient.swift
+++ b/mobile/evidence/ios/Leaf/Sources/Leaf/Components/LeafAsyncImageClient.swift
@@ -2,18 +2,17 @@ import Combine
 import Dependencies
 import SwiftUI
 
-struct LeafAsyncImageClient {
+public struct LeafAsyncImageClient {
     var load: (URL) -> AnyPublisher<Image, Error>
 }
 
-struct LeafAsyncImageClientKey: DependencyKey {
-    static let liveValue = LeafAsyncImageClient.live
-    static let previewValue = LeafAsyncImageClient.preview
-    static let testValue = LeafAsyncImageClient.preview
+public struct LeafAsyncImageClientKey: DependencyKey {
+    public static let liveValue = LeafAsyncImageClient.live
+    public static let testValue = LeafAsyncImageClient.system("checkmark.circle")
 }
 
 extension DependencyValues {
-    var leafAsyncImageClient: LeafAsyncImageClient {
+    public var leafAsyncImageClient: LeafAsyncImageClient {
         get { self[LeafAsyncImageClientKey.self] }
         set { self[LeafAsyncImageClientKey.self] = newValue }
     }
@@ -29,9 +28,7 @@ extension LeafAsyncImageClient {
 }
 
 extension LeafAsyncImageClient {
-    static let preview = LeafAsyncImageClient.system("checkmark.circle")
-    
-    static func system(_ name: String) -> LeafAsyncImageClient {
+    public static func system(_ name: String) -> LeafAsyncImageClient {
         LeafAsyncImageClient { _ in
             Just(Image(systemName: name))
                 .setFailureType(to: Error.self)
@@ -39,13 +36,13 @@ extension LeafAsyncImageClient {
         }
     }
     
-    static let neverLoads = LeafAsyncImageClient { url in
+    public static let neverLoads = LeafAsyncImageClient { url in
         Empty(completeImmediately: false)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
     }
     
-    static let error = LeafAsyncImageClient { url in
+    public static let error = LeafAsyncImageClient { url in
         Fail(error: NSError(domain: "LeafError", code: -1))
             .eraseToAnyPublisher()
     }

--- a/mobile/evidence/ios/Leaf/Tests/LeafTests/LeafAvatarTests.swift
+++ b/mobile/evidence/ios/Leaf/Tests/LeafTests/LeafAvatarTests.swift
@@ -24,6 +24,7 @@ final class LeafAvatarTests: XCTestCase {
     func testLoaded() {
         withDependencies {
             $0.leafAsyncImageClient = .system("checkmark.circle.fill")
+            $0.mainQueue = .immediate
         } operation: {
             let sut = LeafThemeView {
                 LeafAvatar(url: URL.documentsDirectory)
@@ -39,6 +40,7 @@ final class LeafAvatarTests: XCTestCase {
     func testError() {
         withDependencies {
             $0.leafAsyncImageClient = .error
+            $0.mainQueue = .immediate
         } operation: {
             let sut = LeafThemeView {
                 LeafAvatar(url: URL.documentsDirectory)


### PR DESCRIPTION
## Description, motivation and context
- Update min app version to iOS 17 (needed to use new scrolling api)
- Move chat state to separate struct `ChatViewState`
- Create highlight logic in chat list where the list automatically scrolls to an specific message id if it is setup upon view model creation
- Create tests for highlight logic
- Use `LeafAsyncImage` on `Message` preview
- Update `LeafAsyncImage` to show content on main thread

## Screenshots and GIFs (Artifacts)

https://github.com/viniciusaro/evidence/assets/6593876/708b5708-340d-4423-a1e6-1293d1ed7402

## Checklist :leaves:
<!-- Check all items that apply. -->
- [x] Created all unit tests needed

Thank you!
